### PR TITLE
Add org reference to events

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,5 +1,5 @@
 import { glob } from "astro/loaders";
-import { defineCollection, z } from "astro:content";
+import { defineCollection, reference, z } from "astro:content";
 
 const events = defineCollection({
   loader: glob({ base: "./src/content/events", pattern: "**/*.{md,mdx}" }),
@@ -16,6 +16,7 @@ const events = defineCollection({
       rsvpButtonUrl: z.string().url().optional(),
       rsvpButtonText: z.string().optional(),
       tags: z.array(z.string()).optional(),
+      org: reference("orgs"),
     }),
 });
 

--- a/src/content/events/ios-dev-scout/april-2025/index.md
+++ b/src/content/events/ios-dev-scout/april-2025/index.md
@@ -1,6 +1,7 @@
 ---
 title: "iOS Dev Scout Meetup April 2025: Fresh Learnings for Spring 🌸"
 description: "Hello, fellow Apple fans and devs! As sakura petals drift through the breeze in Japan, here in sunny Singapore, our community is blooming too! 🌞🌸. Whether you're a regular at our meetups or it's your first time joining, this is your sign to come out of hibernation and reconnect with fellow iOS folks over good convos and even better vibes."
+org: "ios-dev-scout"
 venue: "NUS Enterprise@Blk71"
 startDate: "24 April 2025"
 startTime: "6:30pm"

--- a/src/content/events/juniordevsg/coding-dojo-april2025/index.md
+++ b/src/content/events/juniordevsg/coding-dojo-april2025/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Developer's Gym - Coding Dojo (Let's Practice TDD)"
 description: "A Coding Dojo is a meeting where a bunch of coders get together to work on a programming challenge. They are there to have fun and to engage in Deliberate Practice in order to improve their skills."
+org: "juniordevsg"
 venue: "Open Government Products"
 startDate: "26 April 2025"
 startTime: "10am"

--- a/src/layouts/EventPost.astro
+++ b/src/layouts/EventPost.astro
@@ -1,6 +1,7 @@
 ---
 import type { CollectionEntry } from "astro:content";
 import { Image } from "astro:assets";
+import { getEntry } from "astro:content";
 import BaseHead from "../components/BaseHead.astro";
 import Header from "../components/Header.astro";
 import Footer from "../components/Footer.astro";
@@ -18,7 +19,10 @@ const {
   heroImage,
   rsvpButtonUrl,
   rsvpButtonText,
+  org,
 } = Astro.props;
+
+const orgData = await getEntry(org);
 ---
 
 <html lang="en">
@@ -62,6 +66,10 @@ const {
       .last-updated-on {
         font-style: italic;
       }
+      .org-name {
+        margin-bottom: 0.5em;
+        color: rgb(var(--gray));
+      }
       .rsvp-button {
         display: inline-block;
         padding: 0.8em 1.6em;
@@ -94,6 +102,7 @@ const {
         <div class="prose">
           <div class="title">
             <h1>{title}</h1>
+            {org && <h4 class="org-name">{orgData.data.title}</h4>}
             <h4 class="date">
               <FormattedEventDate
                 startDate={startDate}

--- a/src/pages/events/index.astro
+++ b/src/pages/events/index.astro
@@ -7,6 +7,8 @@ import { getCollection } from "astro:content";
 import { Image } from "astro:assets";
 import FormattedEventDate from "../../components/FormattedEventDate.astro";
 
+const orgs = await getCollection("orgs");
+
 const events = (await getCollection("events")).sort(
   (a, b) => b.data.startDate.valueOf() - a.data.startDate.valueOf()
 );
@@ -58,11 +60,16 @@ const events = (await getCollection("events")).sort(
         color: rgb(var(--black));
         line-height: 1;
       }
+      .org-name {
+        margin: 0;
+        color: rgb(var(--gray));
+      }
       .date {
         margin: 0;
         color: rgb(var(--gray));
       }
       ul li a:hover h4,
+      ul li a:hover .org-name,
       ul li a:hover .date {
         color: rgb(var(--accent));
       }
@@ -102,6 +109,12 @@ const events = (await getCollection("events")).sort(
                     alt=""
                   />
                   <h4 class="title">{event.data.title}</h4>
+                  <p class="org-name">
+                    {
+                      orgs.find((org) => org.id === event.data.org.id)?.data
+                        .title
+                    }
+                  </p>
                   <p class="date">
                     <FormattedEventDate
                       startDate={event.data.startDate}


### PR DESCRIPTION
Add a new `org` field to the events schema. This references the id from orgs schema, which happens to be name of the folder under `content/orgs`.

Retrieving the reference is pretty trivial in EventPost - we just need a `getEntry` method.

This is a little tricker in the index page however, since references defined in the schema must be queried separately. For now, use a naive approach of querying the entire org collection, then match by `org.id === event.data.org.id`. It's not elegant, but it works.