### PR TITLE
Use an Image instead of string.

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -4,16 +4,21 @@
 import "../styles/global.css";
 import { SITE_TITLE } from "../consts";
 import { getImage } from "astro:assets";
+import type { ImageMetadata } from "astro";
 
 interface Props {
   title: string;
   description: string;
-  image?: string;
+  image?: ImageMetadata | string;
 }
 
 const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 
-const { title, description, image = "/blog-placeholder-1.jpg" } = Astro.props;
+const {
+  title,
+  description,
+  image = "/blog-placeholder-about.jpg",
+} = Astro.props;
 
 const optimizedImage = await getImage({
   src: image,

--- a/src/layouts/EventPost.astro
+++ b/src/layouts/EventPost.astro
@@ -27,7 +27,7 @@ const orgData = await getEntry(org);
 
 <html lang="en">
   <head>
-    <BaseHead title={title} description={description} image={heroImage.src} />
+    <BaseHead title={title} description={description} image={heroImage} />
     <style>
       main {
         width: calc(100% - 2em);

--- a/src/layouts/OrgPage.astro
+++ b/src/layouts/OrgPage.astro
@@ -12,7 +12,7 @@ const { title, description, heroImage } = Astro.props;
 
 <html lang="en">
   <head>
-    <BaseHead title={title} description={description} />
+    <BaseHead title={title} description={description} image={heroImage} />
     <style>
       main {
         width: calc(100% - 2em);


### PR DESCRIPTION
- The original implementation was passing in as a string instead of a ImageMetaData.