### PR TITLE
Fix header UI bug for mobile 

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -148,6 +148,7 @@ import { SITE_TITLE } from "../consts";
           top: 2.75rem;
           left: 0;
           right: 0;
+          z-index: 1;
           
           background-color: var(--header-background-color);
           


### PR DESCRIPTION
Added some z-index to the open `.internal-links` menu to fix the bug where search bar overlaps in mobile.

Fixes #75 