### PR TITLE
Add line separator to date heading

### DIFF
--- a/src/pages/events/index.astro
+++ b/src/pages/events/index.astro
@@ -68,7 +68,12 @@ const groupedEvents = events.reduce((acc, event) => {
           { Object.keys(groupedEvents).length > 0 ? (
             Object.keys(groupedEvents).map((date) => (
               <div class="event-date">
-                <h1 class="text-3xl text-bold text-gray-7 mb-s">{date}</h1>
+                <fieldset style="border-bottom: 0px; border-left: 0px; border-right: 0px; border-color: var(--gray-7);">
+                  <legend class="text-3xl text-bold text-gray-7 mb-s mt-m px-m">
+                    {date}
+                  </legend>
+                </fieldset>
+
                 <ul class="event-list">
                   {
                     groupedEvents[date].map((event) => (


### PR DESCRIPTION
Used the fieldset legend hack (cr: @shiling, thanks! really cool hack I learnt today 😄) to add a line separator on the left and right side of the date heading.

Desktop view:
![image](https://github.com/user-attachments/assets/cc1d7ec8-6ccb-43a0-a444-02ade3fdd08f)

Mobile view:
![image](https://github.com/user-attachments/assets/09726a1f-4645-4c4e-9f49-522edcca1dc8)


