### PR TITLE
Feat: Use NodeJS's Fetch API as it feels more stable

### DIFF
--- a/cli/scrapers/EventbriteParser.test.ts
+++ b/cli/scrapers/EventbriteParser.test.ts
@@ -1,8 +1,6 @@
-import * as cheerio from 'cheerio'
 import { describe, expect, test } from 'vitest'
 import { EventbriteParser } from './EventbriteParser'
-
-const getPage = async (url: string): Promise<cheerio.CheerioAPI> => await cheerio.fromURL(url)
+import { PageScraper } from './PageScraper'
 
 describe('EventbriteParser', () => {
   describe('dateTimeParser', () => {
@@ -80,7 +78,7 @@ describe('EventbriteParser', () => {
       const parser = new EventbriteParser()
 
       const url = 'https://www.eventbrite.sg/e/tech-talks-club-street-the-future-of-aging-tickets-1599917078049'
-      const $ = await getPage(url);
+      const $ = await PageScraper.getPage(url);
 
       const result = await parser.scrapeEventDataFromPage($, url)
 
@@ -124,7 +122,7 @@ describe('EventbriteParser', () => {
       const parser = new EventbriteParser()
 
       const url = 'https://www.eventbrite.com/e/tech-week-singapore-2025-tickets-1604379886429'
-      const $ = await getPage(url);
+      const $ = await PageScraper.getPage(url);
 
       const result = await parser.scrapeEventDataFromPage($, url)
 

--- a/cli/scrapers/LumaParser.test.ts
+++ b/cli/scrapers/LumaParser.test.ts
@@ -1,8 +1,6 @@
-import * as cheerio from 'cheerio'
 import { describe, expect, test } from 'vitest'
 import { LumaParser } from './LumaParser'
-
-const getPage = async (url: string): Promise<cheerio.CheerioAPI> => await cheerio.fromURL(url)
+import { PageScraper } from './PageScraper'
 
 describe('LumaParser', () => {
   describe('single day event', () => {
@@ -10,7 +8,7 @@ describe('LumaParser', () => {
       const parser = new LumaParser()
 
       const url = 'https://lu.ma/85nuq71f'
-      const $ = await getPage(url);
+      const $ = await PageScraper.getPage(url);
 
       const result = await parser.scrapeEventDataFromPage($, url)
 
@@ -39,8 +37,8 @@ describe('LumaParser', () => {
       const parser = new LumaParser()
   
       const url = 'https://lu.ma/y79r0r4g'
-      const $ = await getPage(url);
-  
+      const $ = await PageScraper.getPage(url);
+
       const result = await parser.scrapeEventDataFromPage($, url)
   
       expect(result).toMatchObject({
@@ -68,8 +66,8 @@ describe('LumaParser', () => {
       const parser = new LumaParser()
 
       const url = 'https://lu.ma/i1sng2wi'
-      const $ = await getPage(url);
-  
+      const $ = await PageScraper.getPage(url);
+
       const result = await parser.scrapeEventDataFromPage($, url)
   
       expect(result).toMatchObject({
@@ -100,7 +98,7 @@ describe('LumaParser', () => {
       const parser = new LumaParser()
   
       const url = 'https://lu.ma/lesssg2025'
-      const $ = await getPage(url);
+      const $ = await PageScraper.getPage(url);
 
       const result = await parser.scrapeEventDataFromPage($, url)
 

--- a/cli/scrapers/MeetupParser.test.ts
+++ b/cli/scrapers/MeetupParser.test.ts
@@ -1,8 +1,6 @@
-import * as cheerio from 'cheerio'
 import { describe, expect, test } from 'vitest'
 import { MeetupParser } from './MeetupParser'
-
-const getPage = async (url: string): Promise<cheerio.CheerioAPI> => await cheerio.fromURL(url)
+import { PageScraper } from './PageScraper'
 
 describe('MeetupParser', () => {
   describe('single day event', () => {
@@ -10,7 +8,7 @@ describe('MeetupParser', () => {
       const parser = new MeetupParser();
       
       const url = 'https://www.meetup.com/junior-developers-singapore/events/310333625';
-      const $ = await getPage(url);
+      const $ = await PageScraper.getPage(url);
 
       const result = await parser.scrapeEventDataFromPage($, url)
 

--- a/cli/scrapers/PageScraper.ts
+++ b/cli/scrapers/PageScraper.ts
@@ -17,16 +17,7 @@ export class PageScraper {
   async scrapeEventData(url: string): Promise<ScrapedEventData> {
     try {
       console.log(`Fetching ${url}...`);
-      const $ = await cheerio.fromURL(url, url.includes('meetup.com') ? {
-        requestOptions: {
-          method: "GET",
-          headers: {
-            // Accept header to improve consistency when scraping Meetup.com
-            // https://github.com/devsgowhere/devsgowhere/pull/186
-            accept: "*/*",
-          },
-        },
-      } : undefined);
+      const $ = await PageScraper.getPage(url);
 
       let result: ScrapedEventData
       console.log(`Scraping event data...`);
@@ -126,5 +117,15 @@ export class PageScraper {
 
     console.log('\n🤖 Using automated event data for CI mode');
     return eventData;
+  }
+
+  public static async getPage(url: string): Promise<cheerio.CheerioAPI> {
+    const request = await fetch(url)
+  
+    if (!request.ok)
+      throw new Error(`Failed to fetch page: ${request.status} ${request.statusText}`)
+  
+    const body = await request.text()
+    return cheerio.load(body)
   }
 }


### PR DESCRIPTION
Using Cheerio to fetch web pages seems a little bit flaky.

Change from [`cheerio.fromURL(url)`](https://cheerio.js.org/docs/api/functions/fromURL) to [Node.js Fetch API](https://nodejs.org/docs/v22.19.0/api/globals.html#fetch). Its based on the browser [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch).