### PR TITLE
Task: Add file that could normalize the line feed for Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto


### PR DESCRIPTION
More info here: https://www.aleksandrhovhannisyan.com/blog/crlf-vs-lf-normalizing-line-endings-in-git/

Should switch on [`the core.autocrlf setting`](https://git-scm.com/docs/git-config#Documentation/git-config.txt-coreautocrlf) when developing in Windows.