### PR TITLE
Fix: Use correct GTM measurement ID

### DIFF
--- a/src/consts.ts
+++ b/src/consts.ts
@@ -5,4 +5,4 @@ export const SITE_TITLE = "DevsGoWhere"
 export const SITE_DESCRIPTION = "Discover events for engineers in Singapore! "
 export const DEFAULT_THEME = "theme-tech-blue-aquamarine"
 export const DEFAULT_TIMEZONE = "Asia/Singapore" // default timezone for events
-export const GTM_MEASUREMENT_ID = "G-ZMJNRWWGF9" // Google Tag Manager Measurement ID
+export const GTM_MEASUREMENT_ID = "GTM-PCQCGNWS" // Google Tag Manager Measurement ID


### PR DESCRIPTION
Apparently Google Tag is not enough. Have to use a GTM tag.