### PR TITLE
fix(meetup): replace regex with URL parsing

### DIFF
--- a/cli/EventCLI.ts
+++ b/cli/EventCLI.ts
@@ -440,14 +440,21 @@ export class EventCLI {
   }
 
   private inferOrgUrlFromEventUrl(url: string): string {
-    switch (true) {
-      case url.includes("meetup.com"):
-        const parts = url.split("/")
-        return parts.slice(0, parts.indexOf("www.meetup.com") + 2).join("/")
-      default:
-        console.warn(`⚠️  Unable to infer org url from: '${url}'.`)
-        return url
+    try {
+      const parsedUrl = new URL(url)
+      const host = parsedUrl.hostname.toLowerCase()
+
+      if (host === "meetup.com" || host.endsWith(".meetup.com")) {
+        const firstPathSegment = parsedUrl.pathname.split("/").filter(Boolean)[0]
+        return firstPathSegment
+          ? `${parsedUrl.protocol}//${parsedUrl.host}/${firstPathSegment}`
+          : `${parsedUrl.protocol}//${parsedUrl.host}`
+      }
+    } catch {
+      // Fall through to warning and return original URL.
     }
+
+    console.warn(`⚠️  Unable to infer org url from: '${url}'.`)
     return url
   }
 }


### PR DESCRIPTION
This pull request refactors the logic for inferring an organization URL from an event URL in the `EventCLI` class to improve reliability and correctness, especially for Meetup URLs.

Improvements to URL parsing and inference:

* Replaced the previous string-based logic with URL parsing using the `URL` class for more robust and accurate extraction of the organization portion from Meetup URLs. Now, the function handles both `meetup.com` and subdomains, and correctly extracts the first path segment as the organization.
* Added error handling to gracefully fall back to the original URL and log a warning if URL parsing fails or the format is unrecognized.